### PR TITLE
usage of variable tfvars-files

### DIFF
--- a/aws-profile-select.sh
+++ b/aws-profile-select.sh
@@ -43,7 +43,7 @@ IFS=$IFSBAK
 profiles_len=${#profiles[*]}
 
 function main {
-  parse_arguments
+  # parse_arguments
   printf "Current value of AWS_SDK_LOAD_CONFIG: ${AWS_SDK_LOAD_CONFIG}\n"
   echo
   echo ------------- AWS Profile Select-O-Matic -------------
@@ -58,6 +58,30 @@ function main {
 
   # Show the menu
   selection_menu
+}
+
+read_aws_config() {
+	oldCol=$COLUMNS
+	COLUMNS=6
+	 config_file="$HOME/.aws/config"
+
+    if [ -f "$config_file" ]; then
+        while IFS= read -r line; do
+            if [[ $line == \[* ]]; then
+                current_profile=$(echo "$line" | sed 's/\[\(.*\)\]/\1/')
+            elif [[ $line == role_arn* ]]; then
+                role_arn=$(echo "$line" | awk -F'=' '{print $2}' | tr -d '[:space:]')
+                account_number=$(echo "$role_arn" | cut -d':' -f5)
+
+                if [[ "$account_number" =~ ^[0-9]+$ ]]; then
+                    printf "%s : %s\n" "$account_number" "$current_profile"
+                fi
+            fi
+        done < "$config_file"
+    else
+        echo "AWS config file not found: $config_file"
+    fi
+    COLUMNS=$oldCol
 }
 
 function usage {
@@ -103,7 +127,7 @@ function mfa {
       echo "!! MFA_arn not found. Can't renew session"
     fi
   else
-    echo "MFA Valid"
+    echo "MFA Validi, until: $(date -j -f "%s" ${expiration_date} "%Y-%m-%d %H:%M:%S")"
   fi
 }
 
@@ -120,6 +144,7 @@ function read_selection {
   echo
   printf 'Selection: '
   read choice
+  COLUMN=6
   case $choice in
   '' | *[!0-9\-]*)
     clear
@@ -181,6 +206,10 @@ function read_selection {
 if [ $# -gt 0 ]; then
   while [ ! $# -eq 0 ]; do
     case "$1" in
+    -l)
+	    read_aws_config
+	    break
+	  ;;
     --help | -h)
       usage
       ;;

--- a/tfapply.sh
+++ b/tfapply.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
-# Version: 2024013101
 
-TF_ENV=$(echo $TF_BACKEND | awk 0-F '.' '{print $1}' 2>&1)
+TF_ENV=$(echo $TF_BACKEND | awk -F '.' '{print $1}' 2>&1)
 TF_VARS=$(find . -type f -name "*.tfvars")
 
 

--- a/tfdestroy.sh
+++ b/tfdestroy.sh
@@ -1,21 +1,49 @@
 #!/bin/bash
 
-TF_ENV=$(echo $TF_BACKEND | awk -F '.' '{print $1}')
+TF_ENV=$(echo $TF_BACKEND | awk -F '.' '{print $1}' 2>&1)
+TF_VARS=$(find . -type f -name "*.tfvars")
 
-if [[ $1 == "" ]]; then
-    objects="$(for object in $(terraform state list | grep -vE "^data\." | grep -vE "backend|dynamodb|kms"); do echo -target="${object}"\ ; done)"
-    IFSBAK=$IFS
-    IFS=$'\n'
-    objects=($objects)
-    IFS=$IFSBAK
-    objects_len=${#objects[*]}
-else
-    unset objects
-fi
 
 if [[ -f ${TF_ENV}.tfvars ]]; then
-    # terraform destroy -var-file=${TF_ENV}.tfvars ${objects[*]} $#
-    terraform destroy -var-file=${TF_ENV}.tfvars ${objects[*]} $@
-else
-    terraform destroy ${objects[*]} $@
+    terraform destroy -var-file=${TF_ENV}.tfvars $@
+elif [[ ! -z ${TF_VARS} ]]; then
+
+    TF_VARS=(${TF_VARS})
+    TF_VARS_len=${#TF_VARS[*]}
+
+
+    echo "--- Choose vars-file"
+    echo "-: Quit"
+    for ((i = 0; i < $TF_VARS_len; i++)); do
+        echo "$i: ${TF_VARS[$i]}"
+    done
+    echo
+    printf 'Selection: '
+    read choice
+    COLUMN=6
+    case $choice in
+    '' | *[!0-9\-]*)
+        clear
+        echo Invalid selection. Make a valid selection from the list above or press ctrl+c to exit
+        echo '-> Error: Not a number, and not "-"'
+        echo
+        break
+        ;;
+    esac
+    in_range=false
+    while [ $in_range != true ]; do
+        if [[ $choice == '-' ]]; then
+            break
+        elif (($choice >= 0)) && (($choice <= (${TF_VARS_len}-1))); then
+
+            echo ${TF_VARS[choice]}
+            in_range=true
+            terraform destroy -var-file=${TF_VARS[choice]} $@
+            break
+        else
+            echo "!! Not a valid option"
+            break
+        fi
+    done
+
 fi

--- a/tfplan.sh
+++ b/tfplan.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
-# Version: 2024013101
 
-TF_ENV=$(echo $TF_BACKEND | awk 0-F '.' '{print $1}' 2>&1)
+TF_ENV=$(echo $TF_BACKEND | awk -F '.' '{print $1}' 2>&1)
 TF_VARS=$(find . -type f -name "*.tfvars")
 
 


### PR DESCRIPTION
- work with tfvars files different than backend
- allow tfvars files that don't match a configured backend, or usage with no backend at all
